### PR TITLE
(fix) update "Installing Dependencies" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 From within the root directory:
 
 ```sh
-npm run dev-install
+npm install
 ```
 
 This will handle both client and server-side dependencies as outlined in [package.json](package.json).


### PR DESCRIPTION
- change `npm run dev-install` to `npm install`
