### PR TITLE
(fix) support default values for objects and arrays (resolves #45)

### DIFF
--- a/src/containers/guide/code/reduce.js
+++ b/src/containers/guide/code/reduce.js
@@ -6,7 +6,7 @@ export const reduceSolution =
 `function reduce(collection, accumulator, startValue) {
   each(collection, function(item) {
     if (startValue === undefined) {
-      startValue = collection[0];
+      startValue = item;
     }
     else {
       startValue = accumulator(startValue, item);


### PR DESCRIPTION
- replace `collection[0]` with `item`
